### PR TITLE
kafka consumer added to docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.19-bullseye
+
+WORKDIR /app
+
+COPY . .
+
+RUN go build -o event-whisperer
+
+CMD ["./event-whisperer"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,14 @@
 version: '3'
+
+networks:
+  playful_packets:
+    name: playful_packets
+
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:6.2.0
+    networks:
+      - playful_packets
     ports:
       - "2181:2181"
     environment:
@@ -10,11 +17,30 @@ services:
   kafka:
     image: confluentinc/cp-kafka:6.2.0
     container_name: kafka
+    networks:
+      - playful_packets
     ports:
       - "9092:9092"
     environment:
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
     depends_on:
       - zookeeper
+
+  create-topic:
+    image: confluentinc/cp-kafka:6.2.0
+    networks:
+      - playful_packets
+    depends_on:
+      - kafka
+    command: >
+      bash -c "sleep 60 && kafka-topics --create --topic mytopic --partitions 1 --replication-factor 1 --bootstrap-server kafka:9092"
+
+  event-whisperer:
+    build: .
+    networks:
+      - playful_packets
+    depends_on:
+      create-topic:
+        condition: service_completed_successfully

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-	brokers := "localhost:9092"
+	brokers := "kafka:9092"
 	groupID := "your_consumer_group"
 	topic := "mytopic"
 


### PR DESCRIPTION
After docker-compose is done spinning up containers we can do the following to exec into the kafka container and publish an event. From the docker-compose running console we should then subsequently see the events printed by the consumer.
1. docker exec -it kafka  bash
2. kafka-console-producer --topic mytopic --bootstrap-server localhost:9092

